### PR TITLE
fix dialog display problem

### DIFF
--- a/dialog.php
+++ b/dialog.php
@@ -21,8 +21,7 @@
 <button onclick="codiad.modal.unload(); return false;">Close Terminal</button>
 <script>
     $(function(){ 
-        var wheight = $(window)
-            .outerHeight() - 300;
+        var wheight = $(window).outerHeight() * 0.5;
         $('#terminal').css('height',wheight+'px');
     });
 </script>


### PR DESCRIPTION
the original code did not make the size of dialog fit in each screen size, in some resolutions, the terminal box is out of the dialog. fix this by using relative size.
