### PR TITLE
Fixed iframe path for term.php

### DIFF
--- a/dialog.php
+++ b/dialog.php
@@ -17,11 +17,12 @@
     
 ?>
 <style>#terminal { border: 1px solid #2b2b2b; }</style>
-<iframe id="terminal" width="100%" height="400" src="<?php echo str_replace(BASE_PATH."/","",str_replace("dialog.php", "", $_SERVER['SCRIPT_FILENAME'])); ?>emulator/index.php?id=kd9kdi8nundj"></iframe>
+<iframe id="terminal" width="100%" height="400"></iframe>
 <button onclick="codiad.modal.unload(); return false;">Close Terminal</button>
 <script>
     $(function(){ 
         var wheight = $(window).outerHeight() * 0.5;
         $('#terminal').css('height',wheight+'px');
+        $('#terminal').attr('src', codiad.terminal.path + "emulator/index.php?id=kd9kdi8nundj");
     });
 </script>


### PR DESCRIPTION
Resolved 404 problem while loading iframe with term.php by using a path set via frontend JS instead of backend PHP