### PR TITLE
addressed issue-25: reestablished BLOCKED variable definition

### DIFF
--- a/emulator/term.php
+++ b/emulator/term.php
@@ -7,53 +7,53 @@
     *  This software is released as-is with no warranty and is complete free
     *  for use, modification and redistribution
     */
-    
+
     //////////////////////////////////////////////////////////////////
     // Password
     //////////////////////////////////////////////////////////////////
-    
+
     define('PASSWORD','terminal');
-    
+
     //////////////////////////////////////////////////////////////////
     // Core Stuff
     //////////////////////////////////////////////////////////////////
-    
+
     require_once('../../../common.php');
-    
+
     //////////////////////////////////////////////////////////////////
     // Verify Session or Key
     //////////////////////////////////////////////////////////////////
-    
+
     checkSession();
 
     //////////////////////////////////////////////////////////////////
     // Globals
     //////////////////////////////////////////////////////////////////
-    
+
     define('ROOT',WORKSPACE . '/' . $_SESSION['project']);
-    define(' ','ssh,telnet');
-    
+    define('BLOCKED','telnet');
+
     //////////////////////////////////////////////////////////////////
     // Terminal Class
     //////////////////////////////////////////////////////////////////
-    
+
     class Terminal{
-        
+
         ////////////////////////////////////////////////////
         // Properties
         ////////////////////////////////////////////////////
-        
+
         public $command          = '';
         public $output           = '';
         public $directory        = '';
-        
+
         // Holder for commands fired by system
         public $command_exec     = '';
-        
+
         ////////////////////////////////////////////////////
         // Constructor
         ////////////////////////////////////////////////////
-        
+
         public function __construct(){
             if(!isset($_SESSION['dir']) || empty($_SESSION['dir'])){
                 if(ROOT==''){
@@ -69,26 +69,26 @@
                 $this->ChangeDirectory();
             }
         }
-        
+
         ////////////////////////////////////////////////////
         // Primary call
         ////////////////////////////////////////////////////
-        
+
         public function Process(){
             $this->ParseCommand();
             $this->Execute();
             return $this->output;
         }
-        
+
         ////////////////////////////////////////////////////
         // Parse command for special functions, blocks
         ////////////////////////////////////////////////////
-        
+
         public function ParseCommand(){
-            
+
             // Explode command
             $command_parts = explode(" ",$this->command);
-            
+
             // Handle 'cd' command
             if(in_array('cd',$command_parts)){
                 $cd_key = array_search('cd', $command_parts);
@@ -98,35 +98,35 @@
                 // Remove from command
                 $this->command = str_replace('cd '.$this->directory,'',$this->command);
             }
-            
+
             // Replace text editors with cat
             $editors = array('vim','vi','nano');
             $this->command = str_replace($editors,'cat',$this->command);
-            
+
             // Handle blocked commands
             $blocked = explode(',',BLOCKED);
             if(in_array($command_parts[0],$blocked)){
                 $this->command = 'echo ERROR: Command not allowed';
             }
-            
+
             // Update exec command
             $this->command_exec = $this->command . ' 2>&1';
         }
-        
+
         ////////////////////////////////////////////////////
         // Chnage Directory
         ////////////////////////////////////////////////////
-        
+
         public function ChangeDirectory(){
             chdir($this->directory);
             // Store new directory
             $_SESSION['dir'] = exec('pwd');
         }
-        
+
         ////////////////////////////////////////////////////
         // Execute commands
         ////////////////////////////////////////////////////
-        
+
         public function Execute(){
             //system
             if(function_exists('system')){
@@ -155,45 +155,45 @@
             else{
                 $this->output = 'Command execution not possible on this system';
             }
-        }        
-        
+        }
+
     }
-    
+
     //////////////////////////////////////////////////////////////////
     // Processing
     //////////////////////////////////////////////////////////////////
-    
+
     $command = '';
     if(!empty($_POST['command'])){ $command = $_POST['command']; }
-    
+
     if(strtolower($command=='exit')){
-        
+
         //////////////////////////////////////////////////////////////
         // Exit
         //////////////////////////////////////////////////////////////
-        
+
         $_SESSION['term_auth'] = 'false';
         $output = '[CLOSED]';
-        
+
     }else if(! isset($_SESSION['term_auth']) || $_SESSION['term_auth']!='true'){
-        
+
         //////////////////////////////////////////////////////////////
         // Authentication
         //////////////////////////////////////////////////////////////
-        
+
         if($command==PASSWORD){
             $_SESSION['term_auth'] = 'true';
             $output = '[AUTHENTICATED]';
         }else{
             $output = 'Enter Password:';
         }
-        
+
     }else{
-    
+
         //////////////////////////////////////////////////////////////
         // Execution
         //////////////////////////////////////////////////////////////
-        
+
         // Split &&
         $Terminal = new Terminal();
         $output = '';
@@ -202,10 +202,10 @@
             $Terminal->command = $c;
             $output .= $Terminal->Process();
         }
-    
+
     }
 
-    
+
     echo(htmlentities($output));
 
 


### PR DESCRIPTION
addressed issue-25: reestablished BLOCKED variable definition and enabled SSH by removing from BLOCKED list.

Not sure why my editor has removed all the whitespace on empty lines. If that is an issue let me know and I'll update?