### PR TITLE
Fix issue in replacement of editor by cat

### DIFF
--- a/emulator/term.php
+++ b/emulator/term.php
@@ -100,8 +100,8 @@
             }
             
             // Replace text editors with cat
-            $editors = array('vim','vi','nano');
-            $this->command = str_replace($editors,'cat',$this->command);
+            $editors = array('vim ','vi ','nano ');
+            $this->command = str_replace($editors,'cat ',$this->command);
             
             // Handle blocked commands
             $blocked = explode(',',BLOCKED);


### PR DESCRIPTION
Replacing "vi" should be limited to replacing the vi command, not any combination of "vi" in the command line. Eg. "more victory.txt" is interpreted as "more catctory.txt".