### PR TITLE
Fix text editor replacement

### DIFF
--- a/emulator/term.php
+++ b/emulator/term.php
@@ -101,7 +101,7 @@
             
             // Replace text editors with cat
             $editors = array('vim','vi','nano');
-            $this->command = str_replace($editors,'cat',$this->command);
+            $this->command = preg_replace('/^('.join('|', $editors).')/', 'cat', trim($this->command));
             
             // Handle blocked commands
             $blocked = explode(',',BLOCKED);


### PR DESCRIPTION
Because `command my/nanofile.vi` shouldn't be replaced with `command my/catfile.cat`

Just saw https://github.com/Fluidbyte/Codiad-Terminal/pull/27, but that's another approach (I'm not saying it's better).