### PR TITLE
Start the terminal in the current project's path

### DIFF
--- a/dialog.php
+++ b/dialog.php
@@ -23,6 +23,6 @@
     $(function(){ 
         var wheight = $(window).outerHeight() * 0.5;
         $('#terminal').css('height',wheight+'px');
-        $('#terminal').attr('src', codiad.terminal.path + "emulator/index.php?id=kd9kdi8nundj");
+        $('#terminal').attr('src', codiad.terminal.path + "emulator/index.php?project_path='+encodeURI(codiad.project.getCurrent()));
     });
 </script>

--- a/emulator/index.php
+++ b/emulator/index.php
@@ -16,6 +16,8 @@ require_once('../../../common.php');
 
 checkSession();
 
+$_SESSION['dir'] = $_GET['project_path'];
+
 ?>
 <!doctype html>
 


### PR DESCRIPTION
This allow to have a project's root path not in the WORKSPACE directory and still start in it's directory.
- Get the project's path from the IDE (maybe the backend can, but I don't know codiad enough)
- Set it on the session when the dialog is opened

Also it removes the id argument thing (what is this for ?).