### PR TITLE
Fix ROOT for projects outside WORKSPACE

### DIFF
--- a/emulator/term.php
+++ b/emulator/term.php
@@ -30,7 +30,7 @@
     // Globals
     //////////////////////////////////////////////////////////////////
     
-    define('ROOT',WORKSPACE . '/' . $_SESSION['project']);
+    define('ROOT', $_SESSION['project'][0] == '/' ? $_SESSION['project'] : WORKSPACE.'/'.$_SESSION['project']);
     define(' ','ssh,telnet');
     
     //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This allow to have a project's root path not in the WORKSPACE directory and still start in it's directory.

Supersede #30 .